### PR TITLE
Move project to Project_Work and update loader

### DIFF
--- a/Project_Work/README.md
+++ b/Project_Work/README.md
@@ -21,3 +21,9 @@ PROJECT_ENDPOINT=https://your-azure-endpoint
 
 Avviata l'applicazione, è possibile caricare uno o più file `.pdf` dalla sidebar usando il widget di upload.
 
+Poiché il progetto non include più un `requirements.txt`, assicurati di installare manualmente le dipendenze necessarie. In particolare è richiesto il pacchetto `PyPDF2` per leggere i file PDF:
+
+```bash
+pip install PyPDF2
+```
+

--- a/Project_Work/main.py
+++ b/Project_Work/main.py
@@ -6,6 +6,9 @@ from src.rag_app.pipeline import RAGPipeline
 
 load_dotenv()
 
+# Disabilita il file watcher di Streamlit per evitare errori su file temporanei
+os.environ.setdefault("STREAMLIT_SERVER_FILE_WATCHER_TYPE", "none")
+
 os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"  # solo per evitare warning su Windows
 
 

--- a/Project_Work/src/rag_app/loader.py
+++ b/Project_Work/src/rag_app/loader.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
-from PyPDF2 import PdfReader
+try:
+    from PyPDF2 import PdfReader  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - library optional
+    PdfReader = None
 
 
 class PdfFileLoader:
@@ -14,6 +17,10 @@ class PdfFileLoader:
             raise NotADirectoryError(f"Non è una directory: {folder_path}")
 
     def load(self) -> list[dict]:
+        if PdfReader is None:
+            raise ImportError(
+                "PyPDF2 non installato. Esegui 'pip install PyPDF2' per poter leggere i PDF."
+            )
         results = []
         for file in self.folder_path.glob("*.pdf"):
             try:

--- a/Project_Work/src/rag_app/pipeline.py
+++ b/Project_Work/src/rag_app/pipeline.py
@@ -2,7 +2,11 @@ from langchain_community.vectorstores import FAISS
 from langchain.schema import Document
 
 from .loader import PdfFileLoader
-from PyPDF2 import PdfReader
+
+try:
+    from PyPDF2 import PdfReader  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - library optional
+    PdfReader = None
 from .embedding import AdaEmbeddingModel, LangchainAdaWrapper
 from .anonymizer import TextAnonymizer
 from .chat_model import ChatCompletionModel
@@ -31,6 +35,11 @@ class RAGPipeline:
             )
 
     def add_uploaded_files(self, uploaded_files) -> None:
+        if PdfReader is None:
+            raise ImportError(
+                "PyPDF2 non installato. Esegui 'pip install PyPDF2' per poter leggere i PDF."
+            )
+
         for uploaded_file in uploaded_files:
             try:
                 reader = PdfReader(uploaded_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
--r Giorno_11/requirements.txt


### PR DESCRIPTION
## Summary
- move the RAG project under `Project_Work`
- drop unused NER code so only regex anonymization remains
- load pdf files rather than txt files and drop folder input
- remove the obsolete top-level `requirements.txt`
- disable Streamlit file watcher and show clear error when `PyPDF2` is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ce026eabc832a99556f04a2be4105