### PR TITLE
Ensure exported Excel fields are populated

### DIFF
--- a/workshop_final_project/src.py
+++ b/workshop_final_project/src.py
@@ -191,6 +191,9 @@ def fill_template_for_all_docs(pipeline):
         progress.progress((idx+1)/len(pipeline.documents), text=f"Completato {idx+1}/{len(pipeline.documents)}")
     progress.empty()
     df = pd.DataFrame(rows)
+    # Ensure that exported Excel cells are always filled
+    if not df.empty:
+        df[TEMPLATE_FIELDS] = df[TEMPLATE_FIELDS].replace("", "Da compilare")
     return df
 
 
@@ -292,6 +295,9 @@ def fill_template_for_all_files(pipeline):
         progress.progress((idx+1)/len(files), text=f"Completato {idx+1}/{len(files)}")
     progress.empty()
     df = pd.DataFrame(rows)
+    # Ensure that exported Excel cells are always filled
+    if not df.empty:
+        df[TEMPLATE_FIELDS] = df[TEMPLATE_FIELDS].replace("", "Da compilare")
     return df
 
 


### PR DESCRIPTION
## Summary
- enforce placeholder values when filling data from documents
- apply same fill logic when exporting multiple files

## Testing
- `python -m py_compile workshop_final_project/src.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cedfd572c832aa5731540bce99b90